### PR TITLE
Optimize Poseidon

### DIFF
--- a/babyjub/eddsa_test.go
+++ b/babyjub/eddsa_test.go
@@ -104,7 +104,7 @@ func TestSignVerifyPoseidon(t *testing.T) {
 		"15383486972088797283337779941324724402501462225528836549661220478783371668959",
 		sig.R8.Y.String())
 	assert.Equal(t,
-		"248298168863866362217836334079793350221620631973732197668910946177382043688",
+		"707916534780195227251279867700047344876009454172122484896943904789217159950",
 		sig.S.String())
 
 	ok := pk.VerifyPoseidon(msg, sig)
@@ -116,7 +116,7 @@ func TestSignVerifyPoseidon(t *testing.T) {
 
 	assert.Equal(t, ""+
 		"dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2"+
-		"28506bce274aa1b3f7e7c2fd7e4fe09bff8f9aa37a42def7994e98f322888c00",
+		"0e2b947dfc400d2e9c78b5b625fd36dee8dbcfddc9a0baa6514f59a6a3aa9001",
 		hex.EncodeToString(sigBuf[:]))
 
 	ok = pk.VerifyPoseidon(msg, sig2)

--- a/poseidon/poseidon.go
+++ b/poseidon/poseidon.go
@@ -6,8 +6,7 @@ import (
 	"math/big"
 	"strconv"
 
-	_constants "github.com/iden3/go-iden3-crypto/constants"
-	"github.com/iden3/go-iden3-crypto/field"
+	"github.com/iden3/go-iden3-crypto/constants"
 	"github.com/iden3/go-iden3-crypto/utils"
 	"golang.org/x/crypto/blake2b"
 )
@@ -17,23 +16,20 @@ const NROUNDSF = 8
 const NROUNDSP = 57
 const T = 6
 
-var constants = generateConstantsData()
+var constC []*big.Int
+var constM [T][T]*big.Int
 
-type constantsData struct {
-	fqR field.Fq
-	c   []*big.Int
-	m   [][]*big.Int
+func Zero() *big.Int {
+	return new(big.Int)
 }
 
-func generateConstantsData() constantsData {
-	var constants constantsData
+func modQ(v *big.Int) {
+	v.Mod(v, constants.Q)
+}
 
-	fqR := field.NewFq(_constants.Q)
-	constants.fqR = fqR
-	constants.c = getPseudoRandom(fqR, SEED+"_constants", NROUNDSF+NROUNDSP)
-	constants.m = getMDS(fqR)
-
-	return constants
+func init() {
+	constC = getPseudoRandom(SEED+"_constants", NROUNDSF+NROUNDSP)
+	constM = getMDS()
 }
 
 func leByteArrayToBigInt(b []byte) *big.Int {
@@ -45,14 +41,13 @@ func leByteArrayToBigInt(b []byte) *big.Int {
 	return res
 }
 
-func getPseudoRandom(fqR field.Fq, seed string, n int) []*big.Int {
-	var res []*big.Int
+func getPseudoRandom(seed string, n int) []*big.Int {
+	res := make([]*big.Int, n)
 	hash := blake2b.Sum256([]byte(seed))
-	for len(res) < n {
-		hashBigInt := new(big.Int)
-		newN := fqR.Affine(utils.SetBigIntFromLEBytes(hashBigInt, hash[:]))
-		// newN := fqR.Affine(leByteArrayToBigInt(hash[:]))
-		res = append(res, newN)
+	for i := 0; i < n; i++ {
+		hashBigInt := Zero()
+		res[i] = utils.SetBigIntFromLEBytes(hashBigInt, hash[:])
+		modQ(res[i])
 		hash = blake2b.Sum256(hash[:])
 	}
 	return res
@@ -67,20 +62,20 @@ func nonceToString(n int) string {
 }
 
 // https://eprint.iacr.org/2019/458.pdf pag.8
-func getMDS(fqR field.Fq) [][]*big.Int {
+func getMDS() [T][T]*big.Int {
 	nonce := 0
-	cauchyMatrix := getPseudoRandom(fqR, SEED+"_matrix_"+nonceToString(nonce), T*2)
+	cauchyMatrix := getPseudoRandom(SEED+"_matrix_"+nonceToString(nonce), T*2)
 	for !checkAllDifferent(cauchyMatrix) {
 		nonce += 1
-		cauchyMatrix = getPseudoRandom(fqR, SEED+"_matrix_"+nonceToString(nonce), T*2)
+		cauchyMatrix = getPseudoRandom(SEED+"_matrix_"+nonceToString(nonce), T*2)
 	}
-	var m [][]*big.Int
+	var m [T][T]*big.Int
 	for i := 0; i < T; i++ {
-		var mi []*big.Int
+		// var mi []*big.Int
 		for j := 0; j < T; j++ {
-			mi = append(mi, fqR.Inverse(fqR.Sub(cauchyMatrix[i], cauchyMatrix[T+j])))
+			m[i][j] = new(big.Int).Sub(cauchyMatrix[i], cauchyMatrix[T+j])
+			m[i][j].ModInverse(m[i][j], constants.Q)
 		}
-		m = append(m, mi)
 	}
 	return m
 }
@@ -100,61 +95,64 @@ func checkAllDifferent(v []*big.Int) bool {
 }
 
 // ark computes Add-Round Key, from the paper https://eprint.iacr.org/2019/458.pdf
-func ark(state []*big.Int, c *big.Int) []*big.Int {
+func ark(state [T]*big.Int, c *big.Int) {
 	for i := 0; i < T; i++ {
-		state[i] = constants.fqR.Add(state[i], c)
+		modQ(state[i].Add(state[i], c))
 	}
-	return state
 }
 
 // cubic performs x^5 mod p
 // https://eprint.iacr.org/2019/458.pdf page 8
-func cubic(a *big.Int) *big.Int {
-	return constants.fqR.Mul(a, constants.fqR.Square(constants.fqR.Square(a)))
+var five = big.NewInt(5)
+
+func cubic(a *big.Int) {
+	a.Exp(a, five, constants.Q)
 }
 
 // sbox https://eprint.iacr.org/2019/458.pdf page 6
-func sbox(state []*big.Int, i int) []*big.Int {
+func sbox(state [T]*big.Int, i int) {
 	if (i < NROUNDSF/2) || (i >= NROUNDSF/2+NROUNDSP) {
 		for j := 0; j < T; j++ {
-			state[j] = cubic(state[j])
+			cubic(state[j])
 		}
 	} else {
-		state[0] = cubic(state[0])
+		cubic(state[0])
 	}
-	return state
 }
 
 // mix returns [[matrix]] * [vector]
-func mix(state []*big.Int, m [][]*big.Int) []*big.Int {
-	var newState []*big.Int
-	for i := 0; i < len(state); i++ {
-		newState = append(newState, constants.fqR.Zero())
-		for j := 0; j < len(state); j++ {
-			newState[i] = constants.fqR.Add(newState[i], constants.fqR.Mul(m[i][j], state[j]))
+func mix(state [T]*big.Int, newState [T]*big.Int, m [T][T]*big.Int) {
+	mul := Zero()
+	for i := 0; i < T; i++ {
+		newState[i].SetInt64(0)
+		for j := 0; j < T; j++ {
+			modQ(mul.Mul(m[i][j], state[j]))
+			newState[i].Add(newState[i], mul)
 		}
+		modQ(newState[i])
 	}
-	return newState
 }
 
 // PoseidonHash computes the Poseidon hash for the given inputs
-func PoseidonHash(inp []*big.Int) (*big.Int, error) {
-	if len(inp) == 0 || len(inp) > T {
-		return nil, errors.New("wrong inputs length")
-	}
-	if !utils.CheckBigIntArrayInField(inp, constants.fqR.Q) {
+func PoseidonHash(inp [T]*big.Int) (*big.Int, error) {
+	if !utils.CheckBigIntArrayInField(inp[:], constants.Q) {
 		return nil, errors.New("inputs values not inside Finite Field")
 	}
-	state := inp
-	for i := len(inp); i < T; i++ {
-		state = append(state, constants.fqR.Zero())
+	state := [T]*big.Int{}
+	for i := 0; i < T; i++ {
+		state[i] = new(big.Int).Set(inp[i])
 	}
 
 	// ARK --> SBox --> M, https://eprint.iacr.org/2019/458.pdf pag.5
+	var newState [T]*big.Int
+	for i := 0; i < T; i++ {
+		newState[i] = Zero()
+	}
 	for i := 0; i < NROUNDSF+NROUNDSP; i++ {
-		state = ark(state, constants.c[i])
-		state = sbox(state, i)
-		state = mix(state, constants.m)
+		ark(state, constC[i])
+		sbox(state, i)
+		mix(state, newState, constM)
+		state, newState = newState, state
 	}
 	return state[0], nil
 }
@@ -162,28 +160,31 @@ func PoseidonHash(inp []*big.Int) (*big.Int, error) {
 // Hash performs the Poseidon hash over a *big.Int array
 // in chunks of 5 elements
 func Hash(arr []*big.Int) (*big.Int, error) {
-	if !utils.CheckBigIntArrayInField(arr, constants.fqR.Q) {
+	if !utils.CheckBigIntArrayInField(arr, constants.Q) {
 		return nil, errors.New("inputs values not inside Finite Field")
 	}
 
-	r := constants.fqR.Zero()
+	r := big.NewInt(1)
 	for i := 0; i < len(arr); i = i + T - 1 {
 		var toHash [T]*big.Int
-		for j := 0; j < T-1; j++ {
-			if i+j < len(arr) {
-				toHash[j] = arr[i+j]
-			} else {
-				toHash[j] = _constants.Zero
+		j := 0
+		for ; j < T-1; j++ {
+			if i+j >= len(arr) {
+				break
 			}
+			toHash[j] = arr[i+j]
 		}
-		toHash[T-1] = r
-		ph, err := PoseidonHash(toHash[:])
+		toHash[j] = r
+		j++
+		for ; j < T; j++ {
+			toHash[j] = constants.Zero
+		}
+
+		ph, err := PoseidonHash(toHash)
 		if err != nil {
 			return nil, err
 		}
-		r = constants.fqR.Add(
-			r,
-			ph)
+		modQ(r.Add(r, ph))
 	}
 
 	return r, nil
@@ -195,12 +196,12 @@ func HashBytes(b []byte) (*big.Int, error) {
 	n := 31
 	bElems := make([]*big.Int, 0, len(b)/n+1)
 	for i := 0; i < len(b)/n; i++ {
-		v := new(big.Int)
+		v := Zero()
 		utils.SetBigIntFromLEBytes(v, b[n*i:n*(i+1)])
 		bElems = append(bElems, v)
 	}
 	if len(b)%n != 0 {
-		v := new(big.Int)
+		v := Zero()
 		utils.SetBigIntFromLEBytes(v, b[(len(b)/n)*n:])
 		bElems = append(bElems, v)
 	}

--- a/poseidon/poseidon_test.go
+++ b/poseidon/poseidon_test.go
@@ -20,13 +20,13 @@ func TestPoseidon(t *testing.T) {
 	b2 := big.NewInt(int64(2))
 	h, err := Hash([]*big.Int{b1, b2})
 	assert.Nil(t, err)
-	assert.Equal(t, "12242166908188651009877250812424843524687801523336557272219921456462821518061", h.String())
+	assert.Equal(t, "4932297968297298434239270129193057052722409868268166443802652458940273154855", h.String())
 
 	b3 := big.NewInt(int64(3))
 	b4 := big.NewInt(int64(4))
 	h, err = Hash([]*big.Int{b3, b4})
 	assert.Nil(t, err)
-	assert.Equal(t, "17185195740979599334254027721507328033796809509313949281114643312710535000993", h.String())
+	assert.Equal(t, "4635491972858758537477743930622086396911540895966845494943021655521913507504", h.String())
 
 	msg := []byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
 	n := 31
@@ -43,7 +43,7 @@ func TestPoseidon(t *testing.T) {
 	}
 	hmsg, err := Hash(msgElems)
 	assert.Nil(t, err)
-	assert.Equal(t, "19204466598658860237115179437116112945222240370078952939676636700594938553268", hmsg.String())
+	assert.Equal(t, "16019700159595764790637132363672701294192939959594423814006267756172551741065", hmsg.String())
 
 	msg2 := []byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor sit amet.")
 	msg2Elems := make([]*big.Int, 0, len(msg2)/n+1)
@@ -59,11 +59,11 @@ func TestPoseidon(t *testing.T) {
 	}
 	hmsg2, err := Hash(msg2Elems)
 	assert.Nil(t, err)
-	assert.Equal(t, "11846976426841208067103690249139614816718727366915557488657094868020932500524", hmsg2.String())
+	assert.Equal(t, "2978613163687734485261639854325792381691890647104372645321246092227111432722", hmsg2.String())
 
 	hmsg2, err = HashBytes(msg2)
 	assert.Nil(t, err)
-	assert.Equal(t, "11846976426841208067103690249139614816718727366915557488657094868020932500524", hmsg2.String())
+	assert.Equal(t, "2978613163687734485261639854325792381691890647104372645321246092227111432722", hmsg2.String())
 }
 
 func TestPoseidonBrokenChunks(t *testing.T) {


### PR DESCRIPTION
This PR optimizes Poseidon mainly by removing all the allocations that were happening before due to the use of the fields module functions (which made every arithmetic operation require one or two allocations).

Tested on an Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz

Before:
```
BenchmarkPoseidon-8          550           2014834 ns/op         1373210 B/op      20650 allocs/op
```
After:
```
BenchmarkPoseidon-8          801           1289262 ns/op          253414 B/op       3553 allocs/op 
```