### PR TITLE
Update BabyJubJub signature with Poseidon

### DIFF
--- a/babyjub/eddsa.go
+++ b/babyjub/eddsa.go
@@ -222,8 +222,8 @@ func (k *PrivateKey) SignPoseidon(msg *big.Int) *Signature {
 	r.Mod(r, SubOrder)
 	R8 := NewPoint().Mul(r, B8) // R8 = r * 8 * B
 	A := k.Public().Point()
-	hmInput := []*big.Int{R8.X, R8.Y, A.X, A.Y, msg}
-	hm, err := poseidon.Hash(hmInput) // hm = H1(8*R.x, 8*R.y, A.x, A.y, msg)
+	hmInput := [poseidon.T]*big.Int{R8.X, R8.Y, A.X, A.Y, msg, big.NewInt(int64(0))}
+	hm, err := poseidon.PoseidonHash(hmInput) // hm = H1(8*R.x, 8*R.y, A.x, A.y, msg)
 	if err != nil {
 		panic(err)
 	}
@@ -238,8 +238,8 @@ func (k *PrivateKey) SignPoseidon(msg *big.Int) *Signature {
 // VerifyPoseidon verifies the signature of a message encoded as a big.Int in Zq
 // using blake-512 hash for buffer hashing and Poseidon for big.Int hashing.
 func (p *PublicKey) VerifyPoseidon(msg *big.Int, sig *Signature) bool {
-	hmInput := []*big.Int{sig.R8.X, sig.R8.Y, p.X, p.Y, msg}
-	hm, err := poseidon.Hash(hmInput) // hm = H1(8*R.x, 8*R.y, A.x, A.y, msg)
+	hmInput := [poseidon.T]*big.Int{sig.R8.X, sig.R8.Y, p.X, p.Y, msg, big.NewInt(int64(0))}
+	hm, err := poseidon.PoseidonHash(hmInput) // hm = H1(8*R.x, 8*R.y, A.x, A.y, msg)
 	if err != nil {
 		panic(err)
 	}

--- a/babyjub/eddsa_test.go
+++ b/babyjub/eddsa_test.go
@@ -104,7 +104,7 @@ func TestSignVerifyPoseidon(t *testing.T) {
 		"15383486972088797283337779941324724402501462225528836549661220478783371668959",
 		sig.R8.Y.String())
 	assert.Equal(t,
-		"707916534780195227251279867700047344876009454172122484896943904789217159950",
+		"248298168863866362217836334079793350221620631973732197668910946177382043688",
 		sig.S.String())
 
 	ok := pk.VerifyPoseidon(msg, sig)
@@ -116,7 +116,7 @@ func TestSignVerifyPoseidon(t *testing.T) {
 
 	assert.Equal(t, ""+
 		"dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2"+
-		"0e2b947dfc400d2e9c78b5b625fd36dee8dbcfddc9a0baa6514f59a6a3aa9001",
+		"28506bce274aa1b3f7e7c2fd7e4fe09bff8f9aa37a42def7994e98f322888c00",
 		hex.EncodeToString(sigBuf[:]))
 
 	ok = pk.VerifyPoseidon(msg, sig2)


### PR DESCRIPTION
This PR updates the `SignPoseidon` & `VerifyPoseidon` to use directly `poseidon.PoseidonHash` instead of `poseidon.Hash`.
The `poseidon.Hash` function is for arbitrary length of inputs, and adds extra computation that is not needed for `babyjub.SignPoseidon` and `babyjub.VerifyPoseidon`, as `len({8*R.x, 8*R.y, A.x, A.y, msg}) < poseidon.T` (where `poseidon.T` is `6`).
This allows to avoid unnecessary onchain computation.

This PR comes together with the PR https://github.com/iden3/contracts/pull/27, where the EDDSA BabyJubJub signature verification is done in Solidity.