### PR TITLE
Update Poseidon Hash function names, rm HashBytes

### DIFF
--- a/babyjub/eddsa.go
+++ b/babyjub/eddsa.go
@@ -231,7 +231,7 @@ func (k *PrivateKey) SignPoseidon(msg *big.Int) *Signature {
 	A := k.Public().Point()
 
 	hmInput := [poseidon.T]*big.Int{R8.X, R8.Y, A.X, A.Y, msg, big.NewInt(int64(0))}
-	hm, err := poseidon.PoseidonHash(hmInput) // hm = H1(8*R.x, 8*R.y, A.x, A.y, msg)
+	hm, err := poseidon.Hash(hmInput) // hm = H1(8*R.x, 8*R.y, A.x, A.y, msg)
 	if err != nil {
 		panic(err)
 	}
@@ -248,7 +248,7 @@ func (k *PrivateKey) SignPoseidon(msg *big.Int) *Signature {
 // using blake-512 hash for buffer hashing and Poseidon for big.Int hashing.
 func (p *PublicKey) VerifyPoseidon(msg *big.Int, sig *Signature) bool {
 	hmInput := [poseidon.T]*big.Int{sig.R8.X, sig.R8.Y, p.X, p.Y, msg, big.NewInt(int64(0))}
-	hm, err := poseidon.PoseidonHash(hmInput) // hm = H1(8*R.x, 8*R.y, A.x, A.y, msg)
+	hm, err := poseidon.Hash(hmInput) // hm = H1(8*R.x, 8*R.y, A.x, A.y, msg)
 	if err != nil {
 		panic(err)
 	}

--- a/poseidon/poseidon.go
+++ b/poseidon/poseidon.go
@@ -120,8 +120,8 @@ func mix(state [T]*ff.Element, newState [T]*ff.Element, m [T][T]*ff.Element) {
 	}
 }
 
-// PoseidonHash computes the Poseidon hash for the given inputs
-func PoseidonHash(inpBI [T]*big.Int) (*big.Int, error) {
+// Hash computes the Poseidon hash for the given inputs
+func Hash(inpBI [T]*big.Int) (*big.Int, error) {
 	if !utils.CheckBigIntArrayInField(inpBI[:]) {
 		return nil, errors.New("inputs values not inside Finite Field")
 	}
@@ -148,9 +148,9 @@ func PoseidonHash(inpBI [T]*big.Int) (*big.Int, error) {
 	return r, nil
 }
 
-// Hash performs the Poseidon hash over a ff.Element array
+// HashSlice performs the Poseidon hash over a ff.Element array
 // in chunks of 5 elements
-func Hash(arr []*big.Int) (*big.Int, error) {
+func HashSlice(arr []*big.Int) (*big.Int, error) {
 	r := big.NewInt(int64(1))
 	for i := 0; i < len(arr); i = i + T - 1 {
 		var toHash [T]*big.Int
@@ -167,7 +167,7 @@ func Hash(arr []*big.Int) (*big.Int, error) {
 			toHash[j] = big.NewInt(0)
 		}
 
-		ph, err := PoseidonHash(toHash)
+		ph, err := Hash(toHash)
 		if err != nil {
 			return nil, err
 		}
@@ -175,27 +175,4 @@ func Hash(arr []*big.Int) (*big.Int, error) {
 	}
 
 	return r, nil
-}
-
-// HashBytes hashes a msg byte slice by blocks of 31 bytes encoded as
-// little-endian
-func HashBytes(b []byte) *big.Int {
-	n := 31
-	bElems := make([]*big.Int, 0, len(b)/n+1)
-	for i := 0; i < len(b)/n; i++ {
-		v := big.NewInt(int64(0))
-		utils.SetBigIntFromLEBytes(v, b[n*i:n*(i+1)])
-		bElems = append(bElems, v)
-
-	}
-	if len(b)%n != 0 {
-		v := big.NewInt(int64(0))
-		utils.SetBigIntFromLEBytes(v, b[(len(b)/n)*n:])
-		bElems = append(bElems, v)
-	}
-	h, err := Hash(bElems)
-	if err != nil {
-		panic(err)
-	}
-	return h
 }


### PR DESCRIPTION
Since Poseidon Hash is used because of compatibility in zkSNARK circuits, due
circuit constraints number, the hash method of `[T]*big.Int` is the one directly
compatible with the circuits, is the method which have the `Hash` name on it.
The method that can take arbitrary length of `[]*big.Int` putting them in chunks
of `[T]*big.Int` and iterating, is called `HashSlice`. The `HashBytes` has been
removed, as is a method that will not be used in zkSNARK circuits due high
constraints number.

For zkSNARK circuits, should be used `poseidon.Hash([poseidon.T]*big.Int)`.