### PR TITLE
Babyjubjub separate PointFromSignAndY from p.Decompress

### DIFF
--- a/babyjub/babyjub.go
+++ b/babyjub/babyjub.go
@@ -181,6 +181,14 @@ func (p *Point) Decompress(leBuf [32]byte) (*Point, error) {
 		leBuf[31] = leBuf[31] & 0x7F
 	}
 	utils.SetBigIntFromLEBytes(p.Y, leBuf[:])
+	return PointFromSignAndY(sign, p.Y)
+}
+
+// PointFromSignAndY returns a Point from a Sign and the Y coordinate
+func PointFromSignAndY(sign bool, y *big.Int) (*Point, error) {
+	var p Point
+	p.X = big.NewInt(0)
+	p.Y = y
 	if p.Y.Cmp(constants.Q) >= 0 {
 		return nil, fmt.Errorf("p.y >= Q")
 	}
@@ -209,5 +217,5 @@ func (p *Point) Decompress(leBuf [32]byte) (*Point, error) {
 	}
 	p.X.Mod(p.X, constants.Q)
 
-	return p, nil
+	return &p, nil
 }

--- a/babyjub/babyjub_test.go
+++ b/babyjub/babyjub_test.go
@@ -192,6 +192,20 @@ func TestInSubGroup2(t *testing.T) {
 	assert.Equal(t, true, p.InSubGroup())
 }
 
+func TestPointFromSignAndy(t *testing.T) {
+	x := utils.NewIntFromString(
+		"17777552123799933955779906779655732241715742912184938656739573121738514868268")
+	y := utils.NewIntFromString(
+		"2626589144620713026669568689430873010625803728049924121243784502389097019475")
+	p := &Point{X: x, Y: y}
+
+	sign := PointCoordSign(p.X)
+	p2, err := PointFromSignAndY(sign, p.Y)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, p.X.String(), p2.X.String())
+	assert.Equal(t, p.Y.String(), p2.Y.String())
+}
+
 func TestCompressDecompress1(t *testing.T) {
 	x := utils.NewIntFromString(
 		"17777552123799933955779906779655732241715742912184938656739573121738514868268")


### PR DESCRIPTION
To allow usage from outside directly to the `PointFromSignAndY`