### PR TITLE
Fix Poseidon Hash check for inputs being in Finite Field

### DIFF
--- a/poseidon/poseidon.go
+++ b/poseidon/poseidon.go
@@ -1,6 +1,7 @@
 package poseidon
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -58,6 +59,9 @@ func Hash(inpBI []*big.Int) (*big.Int, error) {
 	t := len(inpBI) + 1
 	if len(inpBI) == 0 || len(inpBI) > len(NROUNDSP) {
 		return nil, fmt.Errorf("invalid inputs length %d, max %d", len(inpBI), len(NROUNDSP)) //nolint:gomnd,lll
+	}
+	if !utils.CheckBigIntArrayInField(inpBI[:]) {
+		return nil, errors.New("inputs values not inside Finite Field")
 	}
 	inp := utils.BigIntArrayToElementArray(inpBI[:])
 


### PR DESCRIPTION
Check was probably unintentionally deleted during Poseidon optimization.
Fixed it. Added unit test.