### PR TITLE
fix bbjj api: return err when hash fails while sign/verify

### DIFF
--- a/babyjub/babyjub_wrapper.go
+++ b/babyjub/babyjub_wrapper.go
@@ -62,7 +62,10 @@ func (w *BjjWrappedPrivateKey) Sign(rand io.Reader, digest []byte, opts crypto.S
 	}
 
 	digestBI := big.NewInt(0).SetBytes(digest)
-	sig := w.privKey.SignPoseidon(digestBI)
+	sig, err := w.privKey.SignPoseidon(digestBI)
+	if err != nil {
+		return nil, err
+	}
 	return sig.Compress().MarshalText()
 }
 


### PR DESCRIPTION
In the babyjubjub package, when inputting a msg that didn't fit in a finite field element, the `poseidon.Hash` method was failing due the value not fitting inside the finite field, but the error was not returned and the end user only saw `false` without knowing why.
Updated the interface of the sign & verify methods so that the error is returned and users can know that the method has failed due the inputted `msg` not fitting inside the finite field used by the babyjubjub.

This modifies the interface of the babyjubjub package, so will affect other projects/repos using this library, maybe worth doing a new tag/release with this change mentioned in the changelog.