### PR TITLE
Add hash.Hash wrapper to goldenposeidon

### DIFF
--- a/goldenposeidon/poseidon_test.go
+++ b/goldenposeidon/poseidon_test.go
@@ -1,100 +1,106 @@
 package poseidon
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 const prime uint64 = 18446744069414584321
+const b0 = uint64(0)
+const b1 = uint64(1)
+const bm1 = prime - 1
+const bM = prime
 
-func TestPoseidonHashCompare(t *testing.T) {
-	b0 := uint64(0)
-	b1 := uint64(1)
-	bm1 := prime - 1
-	bM := prime
+type testInputBytes struct {
+	inpBi [NROUNDSF]uint64
+	capBi [CAPLEN]uint64
+}
 
-	h, err := Hash([NROUNDSF]uint64{b0, b0, b0, b0, b0, b0, b0, b0},
-		[CAPLEN]uint64{b0, b0, b0, b0})
-	assert.Nil(t, err)
-	assert.Equal(t,
-		[CAPLEN]uint64{
+type testVector struct {
+	bytes        testInputBytes
+	expectedHash [CAPLEN]uint64
+}
+
+var testVectors = []testVector{
+	{
+		bytes: testInputBytes{
+			inpBi: [NROUNDSF]uint64{b0, b0, b0, b0, b0, b0, b0, b0},
+			capBi: [CAPLEN]uint64{b0, b0, b0, b0},
+		},
+		expectedHash: [CAPLEN]uint64{
 			4330397376401421145,
 			14124799381142128323,
 			8742572140681234676,
 			14345658006221440202,
-		}, h,
-	)
-
-	h, err = Hash([NROUNDSF]uint64{b1, b1, b1, b1, b1, b1, b1, b1},
-		[CAPLEN]uint64{b1, b1, b1, b1})
-	assert.Nil(t, err)
-	assert.Equal(t,
-		[CAPLEN]uint64{
+		},
+	},
+	{
+		bytes: testInputBytes{
+			inpBi: [NROUNDSF]uint64{b1, b1, b1, b1, b1, b1, b1, b1},
+			capBi: [CAPLEN]uint64{b1, b1, b1, b1},
+		},
+		expectedHash: [CAPLEN]uint64{
 			16428316519797902711,
 			13351830238340666928,
 			682362844289978626,
 			12150588177266359240,
-		}, h,
-	)
-
-	h, err = Hash([NROUNDSF]uint64{b1, b1, b1, b1, b1, b1, b1, b1},
-		[CAPLEN]uint64{b1, b1, b1, b1})
-	assert.Nil(t, err)
-	assert.Equal(t,
-		[CAPLEN]uint64{
-			16428316519797902711,
-			13351830238340666928,
-			682362844289978626,
-			12150588177266359240,
-		}, h,
-	)
-
-	h, err = Hash(
-		[NROUNDSF]uint64{bm1, bm1, bm1, bm1, bm1, bm1, bm1, bm1},
-		[CAPLEN]uint64{bm1, bm1, bm1, bm1},
-	)
-	assert.Nil(t, err)
-	assert.Equal(t,
-		[CAPLEN]uint64{
+		},
+	},
+	{
+		bytes: testInputBytes{
+			inpBi: [NROUNDSF]uint64{bm1, bm1, bm1, bm1, bm1, bm1, bm1, bm1},
+			capBi: [CAPLEN]uint64{bm1, bm1, bm1, bm1},
+		},
+		expectedHash: [CAPLEN]uint64{
 			13691089994624172887,
 			15662102337790434313,
 			14940024623104903507,
 			10772674582659927682,
-		}, h,
-	)
-
-	h, err = Hash([NROUNDSF]uint64{bM, bM, bM, bM, bM, bM, bM, bM},
-		[CAPLEN]uint64{b0, b0, b0, b0})
-	assert.Nil(t, err)
-	assert.Equal(t,
-		[CAPLEN]uint64{
+		},
+	},
+	{
+		bytes: testInputBytes{
+			inpBi: [NROUNDSF]uint64{bM, bM, bM, bM, bM, bM, bM, bM},
+			capBi: [CAPLEN]uint64{b0, b0, b0, b0},
+		},
+		expectedHash: [CAPLEN]uint64{
 			4330397376401421145,
 			14124799381142128323,
 			8742572140681234676,
 			14345658006221440202,
-		}, h,
-	)
-
-	h, err = Hash([NROUNDSF]uint64{
-		uint64(923978),
-		uint64(235763497586),
-		uint64(9827635653498),
-		uint64(112870),
-		uint64(289273673480943876),
-		uint64(230295874986745876),
-		uint64(6254867324987),
-		uint64(2087),
-	}, [CAPLEN]uint64{b0, b0, b0, b0})
-	assert.Nil(t, err)
-	assert.Equal(t,
-		[CAPLEN]uint64{
+		},
+	},
+	{
+		bytes: testInputBytes{
+			inpBi: [NROUNDSF]uint64{uint64(923978),
+				uint64(235763497586),
+				uint64(9827635653498),
+				uint64(112870),
+				uint64(289273673480943876),
+				uint64(230295874986745876),
+				uint64(6254867324987),
+				uint64(2087)},
+			capBi: [CAPLEN]uint64{b0, b0, b0, b0},
+		},
+		expectedHash: [CAPLEN]uint64{
 			1892171027578617759,
 			984732815927439256,
 			7866041765487844082,
 			8161503938059336191,
-		}, h,
-	)
+		},
+	},
+}
+
+func TestPoseidonHashCompare(t *testing.T) {
+	for i, vector := range testVectors {
+		t.Run(fmt.Sprintf("test vector %d", i), func(t *testing.T) {
+			h, err := Hash(vector.bytes.inpBi, vector.bytes.capBi)
+			assert.Nil(t, err)
+			assert.Equal(t, vector.expectedHash, h)
+		})
+	}
 }
 
 func BenchmarkNeptuneHash(b *testing.B) {

--- a/goldenposeidon/poseidon_wrapper.go
+++ b/goldenposeidon/poseidon_wrapper.go
@@ -1,0 +1,87 @@
+package poseidon
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash"
+)
+
+type hasher struct {
+	buf *bytes.Buffer
+}
+
+// Sum returns the Poseidon hash of the input bytes.
+func Sum(b []byte) []byte {
+	h, _ := New()
+	h.Write(b)
+	return h.Sum(nil)
+}
+
+// New returns a new hash.Hash computing the Poseidon hash.
+func New() (hash.Hash, error) {
+	return &hasher{
+		buf: bytes.NewBuffer([]byte{}),
+	}, nil
+}
+
+// Write (via the embedded io.Writer interface) adds more data to the running hash.
+func (h *hasher) Write(p []byte) (n int, err error) {
+	return h.buf.Write(p)
+}
+
+// Sum returns the Poseidon digest of the data.
+func (h *hasher) Sum(b []byte) []byte {
+	var inpBI [NROUNDSF]uint64
+	var capBI [CAPLEN]uint64
+
+	requiredLen := (NROUNDSF + CAPLEN) * 8
+	currentLen := h.buf.Len()
+	extraBytes := currentLen % requiredLen
+
+	// If the buffer has less than the required number of bytes or is not a multiple of requiredLen, pad it with zeros
+	if extraBytes > 0 {
+		padding := make([]byte, requiredLen-extraBytes)
+		h.buf.Write(padding)
+	}
+
+	// Convert bytes to uint64 and fill the input arrays
+	for i := 0; i < NROUNDSF; i++ {
+		inpBI[i] = binary.BigEndian.Uint64(h.buf.Next(8))
+	}
+	for i := 0; i < CAPLEN; i++ {
+		capBI[i] = binary.BigEndian.Uint64(h.buf.Next(8))
+	}
+
+	capBI, _ = Hash(inpBI, capBI)
+
+	// Repeat the sequence if we can read more NROUNDSF*8-byte-chunks from the buffer into inpBI
+	for h.buf.Len() >= requiredLen {
+		for i := 0; i < NROUNDSF; i++ {
+			inpBI[i] = binary.BigEndian.Uint64(h.buf.Next(8))
+		}
+
+		capBI, _ = Hash(inpBI, capBI)
+	}
+
+	capBIBytes := make([]byte, CAPLEN*8)
+	for i, val := range capBI {
+		binary.BigEndian.PutUint64(capBIBytes[i*8:], val)
+	}
+
+	return append(b, capBIBytes...)
+}
+
+// Reset resets the Hash to its initial state.
+func (h *hasher) Reset() {
+	h.buf.Reset()
+}
+
+// Size returns the number of bytes Sum will return.
+func (h *hasher) Size() int {
+	return CAPLEN * 8 // sizeof(uint64)
+}
+
+// BlockSize returns the hash block size.
+func (h *hasher) BlockSize() int {
+	return mLen * 8 // sizeof(uint64)
+}

--- a/goldenposeidon/poseidon_wrapper_test.go
+++ b/goldenposeidon/poseidon_wrapper_test.go
@@ -1,0 +1,50 @@
+package poseidon
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func u64SliceToByteSlice(input []uint64) []byte {
+	inputBytes := bytes.NewBuffer(nil)
+	for _, num := range input {
+		_ = binary.Write(inputBytes, binary.BigEndian, num)
+	}
+	return inputBytes.Bytes()
+}
+
+func TestPoseidonWrapperSum(t *testing.T) {
+	for i, vector := range testVectors {
+		t.Run(fmt.Sprintf("test vector %d", i), func(t *testing.T) {
+			var inputVector [NROUNDSF + CAPLEN]uint64
+			copy(inputVector[:NROUNDSF], vector.bytes.inpBi[:])
+			copy(inputVector[NROUNDSF:], vector.bytes.capBi[:])
+
+			hasher, err := New()
+			require.NoError(t, err)
+			hasher.Write(u64SliceToByteSlice(inputVector[:]))
+			res := hasher.Sum(nil)
+
+			require.NotEmpty(t, res)
+			require.Equal(t, u64SliceToByteSlice(vector.expectedHash[:]), res)
+		})
+	}
+}
+
+func TestPoseidonNewPoseidon(t *testing.T) {
+	for i, vector := range testVectors {
+		t.Run(fmt.Sprintf("test vector %d", i), func(t *testing.T) {
+			var inputVector [NROUNDSF + CAPLEN]uint64
+			copy(inputVector[:NROUNDSF], vector.bytes.inpBi[:])
+			copy(inputVector[NROUNDSF:], vector.bytes.capBi[:])
+
+			res := Sum(u64SliceToByteSlice(inputVector[:]))
+			require.NotEmpty(t, res)
+			require.Equal(t, u64SliceToByteSlice(vector.expectedHash[:]), res)
+		})
+	}
+}


### PR DESCRIPTION
The Poseidon (non-goldilocks) implementation already has the hash.Hash interface, which makes it usable with other libraries that utilize external hash functions. This PR adds an equivalent feature to the goldenposeidon implementation. The majority of the wrapper is basically a conversion between two uint64 arrays (as expected by the non-wrapped goldenposeidon hash function) and slice of bytes, as expected by the hash.Hash interface.

Goldenoseidon's test were refactored a little. They already contain a nice vector of test data. The vector was moved out of test function, so it can be used in the wrapper tests. Both wrapped and non-wrapped goldenposeidons are the same hash function, only with different interfaces, so the wrapped function should behave exactly the same as the non-wrapped function. Unified testing data make it easier to check if the interface introduced bugs, if it fails with the same test case that passes in the raw-interface version.