### PR TITLE
[Poseidon] Add support for setting the initial state

### DIFF
--- a/poseidon/poseidon.go
+++ b/poseidon/poseidon.go
@@ -63,6 +63,11 @@ func mix(state []*ff.Element, t int, m [][]*ff.Element) []*ff.Element {
 
 // Hash computes the Poseidon hash for the given inputs
 func Hash(inpBI []*big.Int) (*big.Int, error) {
+	return HashEx(inpBI, big.NewInt(0))
+}
+
+// HashEx computes the Poseidon hash for the given inputs and given initialState
+func HashEx(inpBI []*big.Int, initialState *big.Int) (*big.Int, error) {
 	t := len(inpBI) + 1
 	if len(inpBI) == 0 || len(inpBI) > len(NROUNDSP) {
 		return nil, fmt.Errorf("invalid inputs length %d, max %d", len(inpBI), len(NROUNDSP))
@@ -80,7 +85,7 @@ func Hash(inpBI []*big.Int) (*big.Int, error) {
 	P := c.p[t-2]
 
 	state := make([]*ff.Element, t)
-	state[0] = zero()
+	state[0] = ff.NewElement().SetBigInt(initialState)
 	copy(state[1:], inp)
 
 	ark(state, C, 0)

--- a/poseidon/poseidon_test.go
+++ b/poseidon/poseidon_test.go
@@ -95,6 +95,25 @@ func TestPoseidonHash(t *testing.T) {
 		h.String())
 }
 
+func TestPoseidonHashEx(t *testing.T) {
+	b0 := big.NewInt(0)
+	b1 := big.NewInt(1)
+	b2 := big.NewInt(2)
+	b3 := big.NewInt(3)
+
+	h, err := HashEx([]*big.Int{b1, b2}, b0)
+	assert.Nil(t, err)
+	assert.Equal(t,
+		"7853200120776062878684798364095072458815029376092732009249414926327459813530",
+		h.String())
+
+	h, err = HashEx([]*big.Int{b1, b2}, b3)
+	assert.Nil(t, err)
+	assert.Equal(t,
+		"18983173721955286408381200682584471402668031072231079754401407247299446548040",
+		h.String())
+}
+
 func TestErrorInputs(t *testing.T) {
 	b0 := big.NewInt(0)
 	b1 := big.NewInt(1)


### PR DESCRIPTION
The initial state is an input in the circom circuit: https://github.com/iden3/circomlib/blob/cff5ab6288b55ef23602221694a6a38a0239dcc0/circuits/poseidon.circom#L69

This PR adds this support to the Golang poseidon hasher, retaining backwards compatibility.