### PR TITLE
Fix utils/CheckBigIntInField

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -90,7 +90,7 @@ func HexDecodeInto(dst, h []byte) error {
 
 // CheckBigIntInField checks if given *big.Int fits in a Field Q element
 func CheckBigIntInField(a *big.Int) bool {
-	return a.Cmp(constants.Q) == -1
+	return (a.Cmp(constants.Q) == -1) && (a.Cmp(constants.Zero) != -1)
 }
 
 // CheckBigIntArrayInField checks if given *big.Int fits in a Field Q element


### PR DESCRIPTION
Hello, I am Minsun from Zellic.

We found a bug for `github.com/iden3/go-iden3-crypto/poseidon` package.

We noticed something weird while replacing inputs in the native hash computation by values with the same remainder modulo the prime modulus of the field `Q` the circuit is defined over, but only if those values where >= the modulus, not with negative ones.

```go
input := []*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3)}

h, _ := poseidon.Hash(input)
```
For this example, `input` being larger or same with `Q` (BN254 curve order) raises an error, because all values in `input` should be within `range(Q)`, but we noticed there is no check for negative numbers, and also no bound check.

Modifying `input` to the following ( `Q + 1` ) raises an error, which is supposed to happen:
```go
Q, _ := new(big.Int).SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
inp_new := Q.Mul(Q, big.NewInt(1))
inp_new = inp_new.Add(Q, big.NewInt(1))

input := []*big.Int{inp_new, big.NewInt(2), big.NewInt(3)}

h, _ := poseidon.Hash(input)
```

However, the following ( `-10000 * Q + 1` ) passes without any error, and gives the same result with `{1, 2, 3}` .
```go
Q, _ := new(big.Int).SetString("21888242871839275222246405745257275088548364400416034343698204186575808495617", 10)
inp_new := Q.Mul(Q, big.NewInt(-10000))
inp_new = inp_new.Add(Q, big.NewInt(1))

input := []*big.Int{inp_new, big.NewInt(2), big.NewInt(3)}

h, _ := poseidon.Hash(input)
```

The reasoning for this is that the native hash computation in the `iden3` library returns an error in the positive case, but reduces values in the negative case. In function `CheckBigIntInField` in https://github.com/iden3/go-iden3-crypto/blob/master/utils/utils.go#L92 :
```go
// CheckBigIntInField checks if given *big.Int fits in a Field Q element
func CheckBigIntInField(a *big.Int) bool {
    return a.Cmp(constants.Q) == -1
}
```
The function is supposed to check `a` is a correct value inside prime field of `Q`, which is same as checking if `a` is included in `range(Q)`.
However this function only checks if value `a` is smaller than `Q`, so arbitrary negative numbers are allowed.



So we suggest changing function `CheckBigIntInField` to the following.
```go
func CheckBigIntInField(a *big.Int) bool {
	return (a.Cmp(constants.Q) == -1) && (a.Cmp(constants.Zero) != -1)
}
```

Despite `CheckBigIntInField` allowing negative numbers, every process afterwards goes through `ff.NewElement().SetBigInt`, which includes modulo arithmatic over `Q`, so this bug doesn't actually leads to a critical behavior. However this hash implementation can lead to some easy collisions, as e.g. `0` and `-Q` hashing to the same thing.