### PR TITLE
Corrected typos

### DIFF
--- a/ff/element.go
+++ b/ff/element.go
@@ -166,7 +166,7 @@ func (z *Element) Div(x, y *Element) *Element {
 }
 
 // Bit returns the i'th bit, with lsb == bit 0.
-// It is the responsability of the caller to convert from Montgomery to Regular form if needed
+// It is the responsibility of the caller to convert from Montgomery to Regular form if needed
 func (z *Element) Bit(i uint64) uint64 {
 	j := i / 64
 	if j >= 4 {

--- a/mimc7/mimc7.go
+++ b/mimc7/mimc7.go
@@ -92,7 +92,7 @@ func HashGeneric(iv *big.Int, arr []*big.Int, nRounds int) (*big.Int, error) {
 }
 
 // MIMC7Hash performs the MIMC7 hash over a *big.Int, using the Finite Field
-// over R and the number of rounds setted in the `constants` variable
+// over R and the number of rounds set in the `constants` variable
 func MIMC7Hash(xInBI, kBI *big.Int) *big.Int { //nolint:golint
 	xIn := ff.NewElement().SetBigInt(xInBI)
 	k := ff.NewElement().SetBigInt(kBI)


### PR DESCRIPTION
### Changes

1. **File:** `/mimc7/mimc7.go`
    - Fixed `setted` to `set` (Line 95)
1. **File:** `/ff/element.go`
    - Fixed `responsability` to `responsibility` (Line 169)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.