### PR TITLE
Typos fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-iden3-crypto [![Go Report Card](https://goreportcard.com/badge/github.com/iden3/go-iden3-crypto)](https://goreportcard.com/report/github.com/iden3/go-iden3-crypto) [![Test Status](https://github.com/iden3/go-iden3-crypto/workflows/Test/badge.svg)](https://github.com/iden3/go-iden3-crypto/actions?query=workflow%3ATest) [![Lint Status](https://github.com/iden3/go-iden3-crypto/workflows/Lint/badge.svg)](https://github.com/iden3/go-iden3-crypto/actions?query=workflow%3ALint) [![GoDoc](https://godoc.org/github.com/iden3/go-iden3-crypto?status.svg)](https://godoc.org/github.com/iden3/go-iden3-crypto)
 
 Go implementation of some cryptographic primitives (that fit inside the SNARK field) used in iden3:
-* BabyJubJub curve arithmetics & EdDSA on it
-* Goldilocks curve arithmetics
+* BabyJubJub curve arithmetic & EdDSA on it
+* Goldilocks curve arithmetic
 * Poseidon hash for BN254
 * Poseidon hash for Goldilocks
 * MIMC7

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,7 +22,7 @@ func NewIntFromString(s string) (*big.Int, error) {
 }
 
 // SwapEndianness swaps the endianness of the value encoded in xs.  If xs is
-// Big-Endian, the result will be Little-Endian and viceversa.
+// Big-Endian, the result will be Little-Endian and vice-versa.
 func SwapEndianness(xs []byte) []byte {
 	ys := make([]byte, len(xs))
 	for i, b := range xs {


### PR DESCRIPTION
### Changes

1. **File:** `/README.md`
    - Fixed `arithmetics` to `arithmetic` (Line 4)
1. **File:** `/utils/utils.go`
    - Fixed `viceversa` to `vice-versa` (Line 25)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.