### PR TITLE
Fix typo: "responsability" → "responsibility" in comments

### DIFF
--- a/ff/element.go
+++ b/ff/element.go
@@ -166,7 +166,7 @@ func (z *Element) Div(x, y *Element) *Element {
 }
 
 // Bit returns the i'th bit, with lsb == bit 0.
-// It is the responsability of the caller to convert from Montgomery to Regular form if needed
+// It is the responsibility of the caller to convert from Montgomery to Regular form if needed
 func (z *Element) Bit(i uint64) uint64 {
 	j := i / 64
 	if j >= 4 {

--- a/ffg/element.go
+++ b/ffg/element.go
@@ -157,7 +157,7 @@ func (z *Element) Div(x, y *Element) *Element {
 }
 
 // Bit returns the i'th bit, with lsb == bit 0.
-// It is the responsability of the caller to convert from Montgomery to Regular form if needed
+// It is the responsibility of the caller to convert from Montgomery to Regular form if needed
 func (z *Element) Bit(i uint64) uint64 {
 	j := i / 64
 	if j >= 1 {


### PR DESCRIPTION


---


**Description:**  
This pull request corrects a typo in the comments of `ff/element.go` and `ffg/element.go`, replacing "responsability" with the correct spelling "responsibility".  

---